### PR TITLE
Team Section: Change user image size to be square

### DIFF
--- a/src/App/components/Sections/Team/UserActive/SingleUserImg/SingleUserImg.scss
+++ b/src/App/components/Sections/Team/UserActive/SingleUserImg/SingleUserImg.scss
@@ -5,16 +5,16 @@
     transition: 0s all;
 
     width: 500px;
-    height: 475px;
+    height: 500px;
 
     @media screen and (max-width: 1199px){
       width: 400px;
-      height: 375px;
+      height: 400px;
     }
 
     @media screen and (max-width: 991px){
       width: 200px;
-      height: 175px;
+      height: 200px;
     }
   }
 }

--- a/src/App/components/Sections/Team/UserInactive/UserList/UserItem/UserItem.scss
+++ b/src/App/components/Sections/Team/UserInactive/UserList/UserItem/UserItem.scss
@@ -3,14 +3,14 @@
 .team-user-item{
   img{  //user image size
     width: 200px;  
-    height: 175px;
+    height: 200px;
     @media screen and (max-width: 991px){
       width: 175px;
-      height: 150px;
+      height: 175px;
     }
     @media screen and (max-width: 767px){
       width: 125px;
-      height: 100px;
+      height: 125px;
     }
   }
   p{
@@ -38,7 +38,7 @@
   .team-user-item-hover{
     display: none;
     width: 200px;
-    height: 175px;
+    height: 200px;
     background-color: rgba(239, 60, 36, 0.9);
   }
 


### PR DESCRIPTION
User image height was changed to equal width of
image for both desktop and mobile. Changes were made
to both inactive user images and active user image.

This fix was needed because user images were squashed
and needed to be a square ratio.